### PR TITLE
Use a new base image for vllm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@
 # Please update any changes made here to
 # docs/source/dev/dockerfile/dockerfile.rst and
 # docs/source/assets/dev/dockerfile-stages-dependency.png
+ARG WOLFI_OS_BASE_IMAGE=none
 
 ARG CUDA_VERSION=12.4.1
 #################### BASE BUILD IMAGE ####################

--- a/Dockerfile
+++ b/Dockerfile
@@ -158,6 +158,8 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 
 ENV VLLM_USAGE_SOURCE=production-docker-image
 ENV VLLM_NCCL_SO_PATH=/usr/lib/python3.10/site-packages/nvidia/nccl/lib/libnccl.so.2
+ENV NUMBA_CACHE_DIR=/workspace/numba_cache
+RUN mkdir -p ${NUMBA_CACHE_DIR}
 RUN chmod -R a+rwx /workspace
 
 USER h2ogpt

--- a/Dockerfile
+++ b/Dockerfile
@@ -139,8 +139,8 @@ WORKDIR /workspace
 # https://github.com/pytorch/pytorch/issues/107960 -- hopefully
 # this won't be needed for future versions of this docker image
 # or future versions of triton.
-RUN ldconfig /usr/local/cuda-$(echo $CUDA_VERSION | cut -d. -f1,2)/lib64/stubs/
-RUN ldconfig /usr/local/cuda-$(echo $CUDA_VERSION | cut -d. -f1,2)/lib64/
+#RUN ldconfig /usr/local/cuda-$(echo $CUDA_VERSION | cut -d. -f1,2)/lib64/stubs/
+#RUN ldconfig /usr/local/cuda-$(echo $CUDA_VERSION | cut -d. -f1,2)/lib64/
 
 # install vllm wheel first, so that torch etc will be installed
 RUN --mount=type=bind,from=build,src=/workspace/dist,target=/workspace/dist \

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ VLLM_BASE_IMAGE   ?= gcr.io/vorvan/h2oai/h2ogpt-vllm-wolfi-base:1
 
 docker_build:
 	docker pull $(VLLM_BASE_IMAGE)
+	docker pull nvidia/cuda:$(VLLM_CUDA_VERSION)-devel-ubuntu22.04
 	docker buildx build --load --build-arg max_jobs=$(NPROCS) --build-arg PYTHON_VERSION=3.10 --build-arg CUDA_VERSION=$(VLLM_CUDA_VERSION) --build-arg WOLFI_OS_BASE_IMAGE=$(VLLM_BASE_IMAGE) --tag $(DOCKER_TEST_IMAGE_VLLM) --file Dockerfile .
 
 docker_push:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+
+VERSION                    := $(shell grep -oP '(?<=__version__ = ")[^"]*' vllm/version.py)
+DOCKER_TEST_IMAGE_VLLM     := harbor.h2o.ai/h2ogpt/test-image-vllm:$(VERSION)
+
+ifeq ($(VERSION),)
+  $(error Failed to extract version number from vllm/version.py)
+endif
+
+VLLM_CUDA_VERSION ?= 12.1.0
+VLLM_BASE_IMAGE   ?= gcr.io/vorvan/h2oai/h2ogpt-vllm-wolfi-base:1
+
+docker_build:
+	docker pull $(VLLM_BASE_IMAGE)
+	DOCKER_BUILDKIT=1 docker build --load --build-arg max_jobs=$(NPROCS) --build-arg PYTHON_VERSION=3.10 --build-arg CUDA_VERSION=$(VLLM_CUDA_VERSION) --build-arg WOLFI_OS_BASE_IMAGE=$(VLLM_BASE_IMAGE) --tag $(DOCKER_TEST_IMAGE_VLLM) --file Dockerfile .
+
+docker_push:
+	docker tag $(DOCKER_TEST_IMAGE_VLLM) gcr.io/vorvan/h2oai/h2ogpte-vllm:$(VERSION)

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ VLLM_BASE_IMAGE   ?= gcr.io/vorvan/h2oai/h2ogpt-vllm-wolfi-base:1
 
 docker_build:
 	docker pull $(VLLM_BASE_IMAGE)
-	DOCKER_BUILDKIT=1 docker build --load --build-arg max_jobs=$(NPROCS) --build-arg PYTHON_VERSION=3.10 --build-arg CUDA_VERSION=$(VLLM_CUDA_VERSION) --build-arg WOLFI_OS_BASE_IMAGE=$(VLLM_BASE_IMAGE) --tag $(DOCKER_TEST_IMAGE_VLLM) --file Dockerfile .
+	docker buildx build --load --build-arg max_jobs=$(NPROCS) --build-arg PYTHON_VERSION=3.10 --build-arg CUDA_VERSION=$(VLLM_CUDA_VERSION) --build-arg WOLFI_OS_BASE_IMAGE=$(VLLM_BASE_IMAGE) --tag $(DOCKER_TEST_IMAGE_VLLM) --file Dockerfile .
 
 docker_push:
 	docker tag $(DOCKER_TEST_IMAGE_VLLM) gcr.io/vorvan/h2oai/h2ogpte-vllm:$(VERSION)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 NPROCS                     := $(shell nproc)
-VERSION                    := $(shell grep -oP '(?<=__version__ = ")[^"]*' vllm/version.py)
+VERSION                    := $(shell grep -oP '(?<=__version__ = ")[^"]*' vllm/version.py)-$(shell git rev-parse --short HEAD)
 DOCKER_TEST_IMAGE_VLLM     := harbor.h2o.ai/h2ogpt/test-image-vllm:$(VERSION)
 
 ifeq ($(VERSION),)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 
+NPROCS                     := $(shell nproc)
 VERSION                    := $(shell grep -oP '(?<=__version__ = ")[^"]*' vllm/version.py)
 DOCKER_TEST_IMAGE_VLLM     := harbor.h2o.ai/h2ogpt/test-image-vllm:$(VERSION)
 

--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,4 @@ docker_build:
 
 docker_push:
 	docker tag $(DOCKER_TEST_IMAGE_VLLM) gcr.io/vorvan/h2oai/h2ogpte-vllm:$(VERSION)
+	docker push gcr.io/vorvan/h2oai/h2ogpte-vllm:$(VERSION)


### PR DESCRIPTION
This PR changed the base image to use a new image based on wolfi-os, and adds a util script to build and push the newly created image to a docker registry.